### PR TITLE
낮은 버전 안드로이드에서 Color Filter 변경

### DIFF
--- a/app/src/main/java/com/loroclip/BookmarkListAdapter.java
+++ b/app/src/main/java/com/loroclip/BookmarkListAdapter.java
@@ -82,9 +82,7 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<BookmarkListAdapte
         View view = holder.viewHolder;
 
         Drawable circle = mContext.getResources().getDrawable(R.drawable.circle);
-        circle.setColorFilter(
-                new PorterDuffColorFilter(bookmark.getColor(),PorterDuff.Mode.OVERLAY)
-        );
+        circle.setColorFilter(bookmark.getColor(), PorterDuff.Mode.MULTIPLY);
 
         ImageView img = (ImageView) view.findViewById(R.id.bookmark_image);
         img.setBackground(circle);

--- a/app/src/main/res/drawable/circle.xml
+++ b/app/src/main/res/drawable/circle.xml
@@ -4,7 +4,7 @@
     android:shape="oval">
 
     <solid
-        android:color="#666666"/>
+        android:color="#FFFFFF"/>
 
     <size
         android:width="120dp"


### PR DESCRIPTION
4.0.4 버전에서 ColorFilter가 좀 잘못 먹었는데 쓰일 수 있도록 바꿨습니다.
