### PR TITLE
Resolve security exception about app private directory

### DIFF
--- a/app/src/main/java/com/loroclip/MainActivity.java
+++ b/app/src/main/java/com/loroclip/MainActivity.java
@@ -7,13 +7,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SyncStatusObserver;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
-import android.os.Environment;
-import android.os.Handler;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.OrientationHelper;
@@ -23,13 +20,9 @@ import android.text.Editable;
 import android.text.InputType;
 import android.text.SpannableStringBuilder;
 import android.text.TextWatcher;
-import android.util.AttributeSet;
 import android.util.Log;
-import android.view.InflateException;
 import android.view.KeyEvent;
-import android.view.LayoutInflater;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -265,66 +258,63 @@ public class MainActivity extends ActionBarActivity implements RecordListAdapter
     }
 
     private void showDownloadRecordDialog(final Context context, final Record record) {
-      String filename = UUID.randomUUID().toString();
-      final String LOROCLIP_PATH = Environment.getExternalStorageDirectory().toString() + "/Android/data/com.loroclip/files/";
-      final String AUDIO_OGG_EXTENSION = ".ogg";
+        final File LOROCLIP_PATH = getExternalFilesDir(null);
+        String filename = UUID.randomUUID().toString();
+        final String AUDIO_OGG_EXTENSION = ".ogg";
 
-      final File recordFile = new File(LOROCLIP_PATH, filename + AUDIO_OGG_EXTENSION);
+        final File recordFile = new File(LOROCLIP_PATH, filename + AUDIO_OGG_EXTENSION);
 
-      new MaterialDialog.Builder(context)
-          .title(R.string.record_not_found)
-          .content(R.string.file_download_required)
-          .callback(new MaterialDialog.ButtonCallback() {
+        new MaterialDialog.Builder(context)
+            .title(R.string.record_not_found)
+            .content(R.string.file_download_required)
+            .callback(new MaterialDialog.ButtonCallback() {
             @Override
             public void onPositive(MaterialDialog dialog) {
-              final ProgressDialog progressDialog = new ProgressDialog(context);
-              progressDialog.setMessage("Downloading..");
-              progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-              progressDialog.setMax(100);
-              progressDialog.setOnKeyListener(new DialogInterface.OnKeyListener() {
-                @Override
-                public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
-                  if (keyCode == KeyEvent.KEYCODE_BACK) {
-                    Ion.getDefault(context).cancelAll();
-                  }
-                  return true;
-                }
-              });
-              progressDialog.setCanceledOnTouchOutside(false);
-              progressDialog.show();
+                final ProgressDialog progressDialog = new ProgressDialog(context);
+                progressDialog.setMessage("Downloading..");
+                progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+                progressDialog.setMax(100);
+                progressDialog.setOnKeyListener(new DialogInterface.OnKeyListener() {
+                    @Override
+                    public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
+                        if (keyCode == KeyEvent.KEYCODE_BACK) {
+                            Ion.getDefault(context).cancelAll();
+                        }
+                        return true;
+                    }
+                });
+                progressDialog.setCanceledOnTouchOutside(false);
+                progressDialog.show();
 
-              Ion.with(context)
-                  .load(record.getRemoteFilePath())
-                  .progressDialog(progressDialog)
-                  .progress(new ProgressCallback() {
+                Ion.with(context)
+                    .load(record.getRemoteFilePath())
+                    .progressDialog(progressDialog)
+                    .progress(new ProgressCallback() {
                     @Override
                     public void onProgress(long downloaded, long total) {
-                      progressDialog.setProgress((int) (downloaded * 100 / total));
+                        progressDialog.setProgress((int) (downloaded * 100 / total));
                     }
-
-
-                  })
-                  .write(recordFile)
-                  .setCallback(new FutureCallback<File>() {
+                })
+                .write(recordFile)
+                .setCallback(new FutureCallback<File>() {
                     @Override
                     public void onCompleted(Exception e, File result) {
-                      progressDialog.dismiss();
+                        progressDialog.dismiss();
+                        if (result != null) {
+                            record.setLocalFile(result);
+                            record.save();
 
-                      if (result != null) {
-                        record.setLocalFile(result);
-                        record.save();
-
-                        Intent intent = new Intent(context, LoroClipEditActivity.class);
-                        intent.putExtra("record_id", record.getId());
-                        context.startActivity(intent);
-                      }
+                            Intent intent = new Intent(context, LoroClipEditActivity.class);
+                            intent.putExtra("record_id", record.getId());
+                            context.startActivity(intent);
+                        }
                     }
-                  });
+                });
             }
-          })
-          .positiveText(R.string.Download)
-          .negativeText(R.string.cancel)
-          .show();
+        })
+        .positiveText(R.string.Download)
+        .negativeText(R.string.cancel)
+        .show();
     }
 
     @Override


### PR DESCRIPTION
파일 다운로드 창이 바로 닫히던 문제를 해결합니다.

문제의 여지는 크게 2개가 있는 것 같은데, 
1. `Environment.getExternalStorageDirectory` 와 다르게 `Context.getExternalFilesDir` 는 디렉터리가 없을 경우 만들어줍니다.
2. App private directory인데 직접 접근하려고 하는 것에 대한 문제가 있다? - http://stackoverflow.com/a/28829017

일단 제가 발견한 문제는 1이었는데 현재 가진 디바이스에서는 다 해결된 것 같습니다.
